### PR TITLE
added -y to install, because it was failing without it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install tensorboardX
 RUN pip install gym[atari]
 RUN pip install git+https://github.com/JKCooper2/gym-bandits#egg=gym-bandits
 RUN apt-get update 
-RUN apt-get install pandoc
-RUN apt-get install texlive-xetex
+RUN apt-get -y install pandoc
+RUN apt-get -y install texlive-xetex


### PR DESCRIPTION
`apt-get install pandoc` was failing, so I added `-y` as default answer. Same for `texlive-xetex`